### PR TITLE
doc_ss: fix typo of lab1 doc

### DIFF
--- a/tinykv/doc_ss/lab1.md
+++ b/tinykv/doc_ss/lab1.md
@@ -103,7 +103,7 @@ There are some important concepts and abstracts, some of which are already refer
 The above concepts or abstractions are about the raft instance. The following concepts are built above the raft instance or `RawNode`.
 - `Region`. A region is a raft group and is responsible for the read/write requests processing related to specific key ranges.
 - `Peer`. A peer is a member of a raft group or a region, by default 3 replicas are used and a region will have 3 different peers. A peer will have a `RawNode` inside which contains a raft instance.
-- `raftWorker`. The worker to process all the client requests routed to different region leaders or leader peers.
+- `raftWorker`. The worker to process all the client requests routed to different region leaders or region peers.
 - `peerMsgHandler`. The delegate used to process the client requests for a specific leader peer.
 - `applyWorker`. After the proposed requests and the related logs are committed, correspond apply requests will be routed to the `applyWorker`, then these logs will be applied to the state machine which is the `badger` storage engine in tinykv.
 


### PR DESCRIPTION
Signed-off-by: IcePigZDB <icepigzdb@gmail.com>
It seems to be a small typo.