### PR TITLE
readme: update tinykv make usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Rather than a course, you can try TinyKV by deploying a real cluster, and intera
 
 ```
 cd tinykv
-make default
+make kv scheduler
 ```
 
 It builds the binary of `tinykv-server` and `tinyscheduler-server` to `bin` dir.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Rather than a course, you can try TinyKV by deploying a real cluster, and intera
 
 ```
 cd tinykv
-make kv
+make default
 ```
 
 It builds the binary of `tinykv-server` and `tinyscheduler-server` to `bin` dir.
@@ -66,6 +66,7 @@ It builds the binary of `tinykv-server` and `tinyscheduler-server` to `bin` dir.
 cd tinysql
 make server
 ```
+
 It buillds the binary of `tinysql-server` to `bin` dir.
 
 


### PR DESCRIPTION
`make kv` only build `tinykv-server` binary, adding `make scheduler` to build `tinyscheduler-server` meets the description in readme. `make default` is defined as `make kv scheduler`, but  is not obvious. So  how about change to `make kv scheduler`?